### PR TITLE
Add include_time_key to kinesis fluent conf

### DIFF
--- a/docker-image/v0.12/alpine-kinesis/conf/fluent.conf
+++ b/docker-image/v0.12/alpine-kinesis/conf/fluent.conf
@@ -9,6 +9,7 @@
   @id out_kinesis_streams
   region "#{ENV['FLUENT_KINESIS_STREAMS_REGION'] || nil}"
   stream_name "#{ENV['FLUENT_KINESIS_STREAMS_STREAM_NAME']}"
+  include_time_key "#{ENV['FLUENT_KINESIS_STREAMS_INCLUDE_TIME_KEY'] || false}"
   flush_interval 1
   buffer_chunk_limit 1m
   try_flush_interval 0.1

--- a/docker-image/v0.12/debian-kinesis/conf/fluent.conf
+++ b/docker-image/v0.12/debian-kinesis/conf/fluent.conf
@@ -10,6 +10,7 @@
   @id out_kinesis_streams
   region "#{ENV['FLUENT_KINESIS_STREAMS_REGION'] || nil}"
   stream_name "#{ENV['FLUENT_KINESIS_STREAMS_STREAM_NAME']}"
+  include_time_key "#{ENV['FLUENT_KINESIS_STREAMS_INCLUDE_TIME_KEY'] || false}"
   flush_interval 1
   buffer_chunk_limit 1m
   try_flush_interval 0.1

--- a/docker-image/v1.2/debian-kinesis/conf/fluent.conf
+++ b/docker-image/v1.2/debian-kinesis/conf/fluent.conf
@@ -10,6 +10,7 @@
   @id out_kinesis_streams
   region "#{ENV['FLUENT_KINESIS_STREAMS_REGION'] || nil}"
   stream_name "#{ENV['FLUENT_KINESIS_STREAMS_STREAM_NAME']}"
+  include_time_key "#{ENV['FLUENT_KINESIS_STREAMS_INCLUDE_TIME_KEY'] || false}"
   <buffer>
     flush_interval 1
     chunk_limit_size 1m

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -250,6 +250,7 @@
   @id out_kinesis_streams
   region "#{ENV['FLUENT_KINESIS_STREAMS_REGION'] || nil}"
   stream_name "#{ENV['FLUENT_KINESIS_STREAMS_STREAM_NAME']}"
+  include_time_key "#{ENV['FLUENT_KINESIS_STREAMS_INCLUDE_TIME_KEY'] || false}"
 <% if is_v1 %>
   <buffer>
     flush_interval 1


### PR DESCRIPTION
Hi @shiftky!
I was using your branch to send logs from Kubernetes -> Kinesis -> Elasticsearch and needed a timestamp for each log. This boolean adds timestamps to each log as `time` on the Kinesis side. I figured this is something worth having for https://github.com/fluent/fluentd-kubernetes-daemonset/pull/159. Let me know if you have any questions.